### PR TITLE
feat: mpris封面显示

### DIFF
--- a/pkg/state_handler/mpris_player.go
+++ b/pkg/state_handler/mpris_player.go
@@ -12,6 +12,7 @@ import (
 	"github.com/godbus/dbus/v5/prop"
 	"github.com/pkg/errors"
 	"go-musicfox/pkg/player"
+	"go-musicfox/utils"
 )
 
 // Player is a DBus object satisfying the `org.mpris.MediaPlayer2.Player` interface.
@@ -183,7 +184,7 @@ func MapFromPlayingInfo(info PlayingInfo) MetadataMap {
 	m := &MetadataMap{
 		"mpris:trackid": dbus.ObjectPath(fmt.Sprintf("/org/mpd/Tracks/%d", info.TrackID)),
 		"mpris:length":  info.TotalDuration / time.Microsecond,
-		"mpris:artUrl":  info.PicUrl,
+		"mpris:artUrl":  utils.AddResizeParamForPicUrl(info.PicUrl, 1024),
 	}
 
 	m.nonEmptyString("xesam:album", info.Album)

--- a/pkg/state_handler/mpris_player.go
+++ b/pkg/state_handler/mpris_player.go
@@ -183,6 +183,7 @@ func MapFromPlayingInfo(info PlayingInfo) MetadataMap {
 	m := &MetadataMap{
 		"mpris:trackid": dbus.ObjectPath(fmt.Sprintf("/org/mpd/Tracks/%d", info.TrackID)),
 		"mpris:length":  info.TotalDuration / time.Microsecond,
+		"mpris:artUrl":  info.PicUrl,
 	}
 
 	m.nonEmptyString("xesam:album", info.Album)

--- a/pkg/ui/player.go
+++ b/pkg/ui/player.go
@@ -384,10 +384,6 @@ func (p *Player) LocatePlayingSong() {
 
 // PlaySong 播放歌曲
 func (p *Player) PlaySong(song structs.Song, direction PlayDirection) error {
-	// PicUrl模糊处理下，不然占网络
-	if song.PicUrl != "" {
-		song.PicUrl += "?param=60y60"
-	}
 
 	loading := NewLoading(p.model)
 	loading.start()
@@ -435,7 +431,7 @@ func (p *Player) PlaySong(song structs.Song, direction PlayDirection) error {
 	go utils.Notify(utils.NotifyContent{
 		Title:   "正在播放: " + song.Name,
 		Text:    fmt.Sprintf("%s - %s", song.ArtistName(), song.Album.Name),
-		Icon:    song.PicUrl,
+		Icon:    utils.AddResizeParamForPicUrl(song.PicUrl, 60),
 		Url:     utils.WebUrlOfSong(song.Id),
 		GroupId: constants.GroupID,
 	})

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -260,7 +260,7 @@ func DownloadMusic(song structs.Song) {
 			}
 			defer tag.Close()
 			tag.SetDefaultEncoding(id3v2.EncodingUTF8)
-			if imgResp, err := http.Get(song.PicUrl + "?param=1024y1024"); err == nil {
+			if imgResp, err := http.Get(AddResizeParamForPicUrl(song.PicUrl, 1024)); err == nil {
 				defer imgResp.Body.Close()
 				if data, err := io.ReadAll(imgResp.Body); err == nil {
 					tag.AddAttachedPicture(id3v2.PictureFrame{
@@ -288,7 +288,7 @@ func DownloadMusic(song structs.Song) {
 			_ = metadata.SetAlbumArtist(song.Album.ArtistName())
 			_ = metadata.SetTitle(song.Name)
 			if flac, ok := metadata.(*songtag.FLAC); ok && song.PicUrl != "" {
-				if imgResp, err := http.Get(song.PicUrl + "?param=1024y1024"); err == nil {
+				if imgResp, err := http.Get(AddResizeParamForPicUrl(song.PicUrl, 1024)); err == nil {
 					defer imgResp.Body.Close()
 					if data, err := io.ReadAll(imgResp.Body); err == nil {
 						img, _ := flacpicture.NewFromImageData(flacpicture.PictureTypeFrontCover, "cover", data, "image/jpeg")
@@ -442,4 +442,11 @@ func IsSameDate(t1, t2 time.Time) bool {
 	y1, m1, d1 := t1.Date()
 	y2, m2, d2 := t2.Date()
 	return y1 == y2 && m1 == m2 && d1 == d2
+}
+
+func AddResizeParamForPicUrl(picurl string, size int64) string {
+	if picurl == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s?param=%dy%d", picurl, size, size)
 }


### PR DESCRIPTION
添加 `utils.AddResizeParamForPicUrl` 函数进行 `PicUrl` 的拼接，程序内仍使用低分辨率封面保证请求速度，只对 mpris 传递高分辨率封面 url